### PR TITLE
Add support for non-encoded content tags

### DIFF
--- a/Pod/Classes/AlamofireRSSParser.swift
+++ b/Pod/Classes/AlamofireRSSParser.swift
@@ -146,7 +146,7 @@ open class AlamofireRSSParser: NSObject, XMLParserDelegate {
                 currentItem.itemDescription = self.currentString
             }
             
-            if (elementName == "content:encoded") {
+            if ((elementName == "content:encoded") || (elementName == "content")) {
                 currentItem.content = self.currentString
             }
             


### PR DESCRIPTION
I was having issues parsing the content for the Github RSS feeds. Turns out they just use a `<content>` tag and not `<content:encoded>`. This PR adds that.