### PR TITLE
Parse RSS item category elements

### DIFF
--- a/Pod/Classes/AlamofireRSSParser.swift
+++ b/Pod/Classes/AlamofireRSSParser.swift
@@ -208,6 +208,9 @@ open class AlamofireRSSParser: NSObject, XMLParserDelegate {
                 }
             }
             
+            if (elementName == "category") {
+                currentItem.categories.append(self.currentString)
+            }
             
         //if we're at the top level
         } else {

--- a/Pod/Classes/RSSItem.swift
+++ b/Pod/Classes/RSSItem.swift
@@ -15,6 +15,7 @@ import Foundation
 open class RSSItem: CustomStringConvertible {
     open var title: String? = nil
     open var link: String? = nil
+    open var categories = [String]()
     
     /**
         Upon setting this property the `itemDescription` will be scanned for HTML and all image urls will be extracted and stored in `imagesFromDescription`


### PR DESCRIPTION
Add parsing of category element(s) for feed items.

As per [RSS 2.0 spec](https://cyber.harvard.edu/rss/rss.html), category elements in the items specify one or more categories that the item belongs to.